### PR TITLE
fix: setup pr mode for ts sdk generation

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -9,6 +9,7 @@ groups:
           token: ${FERN_NPM_TOKEN}
         github:
           repository: squidex/sdk-node
+          mode: pull-request
         config:
           allowCustomFetcher: true
           includeContentHeadersOnFileDownloadResponse: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "squidex",
-  "version": "0.11.11"
+  "version": "0.13.0"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "squidex",
-  "version": "0.11.7-rc3"
+  "version": "0.11.11"
 }


### PR DESCRIPTION
Now when you generate the TS SDK, it will open a PR instead of directly overwriting main. 