### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.1
       
       - name: Download Fern
         run: npm install -g fern-api
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.1
       
       - name: Download Fern
         run: npm install -g fern-api


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.1](https://github.com/actions/setup-node/releases/tag/v4.0.1)** on 2023-12-18T11:05:34Z
